### PR TITLE
Simplify "basic installation" notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ On Mac OSX, you can use homebrew as package manager: http://mxcl.github.com/home
  * Copy and adjust database configuration (`cp config/database.yml.example config/database.yml`)
  * Copy secrets configuration (`cp config/secrets.yml.example config/secrets.yml`)
  * Copy s3 configuration (`cp config/s3.yml.example config/s3.yml`)
- * Create the database ggtracker needs (`mysql -u root` and then `create database ggtracker_development;` and then `quit`)
- * Run migrations (`bundle exec rake db:migrate`)
+ * Create the database ggtracker needs (`rake db:create`)
+ * Load the latest database schema (`bundle exec rake db:schema:load`)
 
 If you want to be able to upload replays, you'll need to have an
 Amazon S3 account.  After setting that up, edit your config/s3.yml

--- a/README.md
+++ b/README.md
@@ -68,9 +68,7 @@ find each other correctly.
 #### Ruby (rspec)
 
  The first time you run tests, set up the test database with:
- * `mysql -u root`
- ** `create database ggtracker_test;`
- ** `quit`
+ * `rake db:create`
  * `rake db:test:prepare`
 
  To run tests: `bundle exec rspec`


### PR DESCRIPTION
Use the Rails-provided rake task for creating the dev database.

Change database-schema loading instructions, which is more future-proof.  Running migrations on the latest build resulted in a schema.rb difference:

```
$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

  modified:   ../db/schema.rb

no changes added to commit (use "git add" and/or "git commit -a")
$ cd ..
$ git diff
diff --git a/db/schema.rb b/db/schema.rb
index 6c263e3..904a869 100644
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -95,7 +95,6 @@ ActiveRecord::Schema.define(:version => 20131101180159) do
     t.datetime "created_at",                                :null => false
     t.datetime "updated_at",                                :null => false
     t.string   "handle"
-    t.boolean  "anonymous",              :default => false
     t.boolean  "guest",                  :default => false
     t.datetime "processing_timestamp"
     t.string   "access_token"
```
