### PR TITLE
Fix time on lotv army chart.

### DIFF
--- a/app/assets/javascripts/angular/controllers/match.js
+++ b/app/assets/javascripts/angular/controllers/match.js
@@ -44,7 +44,7 @@ function($scope, $window, $route, $location, $element, Match) {
 //    console.log("matchscope", $scope);
   $scope.$watch('current_frame', function(v) {
     if(v) { 
-      $scope.current_time = Sc2.frameToTime(v); 
+      $scope.current_time = Sc2.frameToTime(v, $scope.match.expansion);
       $scope.time_has_been_set = true
     }
   });

--- a/app/assets/javascripts/angular/directives/armychart.js
+++ b/app/assets/javascripts/angular/directives/armychart.js
@@ -115,7 +115,7 @@ gg.directive('armychart', ['$location', '$timeout', function($location, $timeout
       scope.freeze = function(frame, updateURL) {
         switch(typeof frame) {
           case "number": frame = frame; break;
-          case "string": frame = Sc2.timeToFrame(frame); break;
+          case "string": frame = Sc2.timeToFrame(frame, scope.match.expansion); break;
           default: return false;
         }
 
@@ -162,7 +162,7 @@ gg.directive('armychart', ['$location', '$timeout', function($location, $timeout
         if(typeof e == "number") {
           frame = e;
         } else if(typeof e == "string") {
-          frame = Sc2.timeToFrame(e);
+          frame = Sc2.timeToFrame(e, scope.match.expansion);
         } else {
           // If clicked on the background, we have xAxis on the event, if clicked
           // on a series, we'll have the point.

--- a/app/assets/javascripts/angular/helpers/sc2.js
+++ b/app/assets/javascripts/angular/helpers/sc2.js
@@ -258,9 +258,13 @@ for (var expansion_tag in Sc2.armyUnits) {
 
 // I'd rather stuff these here, than in Match
 
-Sc2.frameToTime = function(frame) {
-  minute = Math.floor(frame / (60 * 16));
-  second = Math.floor((frame / 16) % 60).toString();
+Sc2.frameToTime = function(frame, expansion) {
+  fps = 16;
+  if (expansion >= 2) {
+    fps *= 1.4;
+  }
+  minute = Math.floor(frame / (60 * fps));
+  second = Math.floor((frame / fps) % 60).toString();
   if (second.length < 2) {
     second = "0" + second;
   }
@@ -271,7 +275,11 @@ Sc2.timeToFrame = function(time) {
   parts = time.split(':');
   seconds = parseInt(parts[parts.length-1]);
   minutes = parseInt(parts[parts.length-2]);
-  frame = ((minutes*60) + seconds) * 16;
+  fps = 16;
+  if (expansion >= 2) {
+    fps *= 1.4;
+  }
+  frame = ((minutes*60) + seconds) * fps;
   return frame;
 }
 


### PR DESCRIPTION
This seems to fix the army chart current time for lotv replays, while keeping backward compatibility.

I'm not strong enough in Angular to understand how I manually test the timeToFrame function, so I don't know if that it working correctly yet.

@dsjoerg could you point in the right direction?
