### PR TITLE
Display base completion and saturation times on LotV time-scale.

### DIFF
--- a/app/assets/javascripts/angular/resources/match.js
+++ b/app/assets/javascripts/angular/resources/match.js
@@ -103,20 +103,20 @@ Entity.prototype.race_macro_pretty = function() {
 
 Entity.prototype.mdelta2 = function() {
     if (this.stats == null ||
-        this.stats.mineral_saturation_2 == null ||
-        this.stats.miningbase_2 == null) {
+        this.stats.mineral_saturation_2_adjusted == null ||
+        this.stats.miningbase_2_adjusted == null) {
         return null;
     }
-    return Math.max(0, this.stats.mineral_saturation_2 - this.stats.miningbase_2);
+    return Math.max(0, this.stats.mineral_saturation_2_adjusted - this.stats.miningbase_2_adjusted);
 }
 
 Entity.prototype.mdelta3 = function() {
     if (this.stats == null ||
-        this.stats.mineral_saturation_3 == null ||
-        this.stats.miningbase_3 == null) {
+        this.stats.mineral_saturation_3_adjusted == null ||
+        this.stats.miningbase_3_adjusted == null) {
         return null;
     }
-    return Math.max(0, this.stats.mineral_saturation_3 - this.stats.miningbase_3);
+    return Math.max(0, this.stats.mineral_saturation_3_adjusted - this.stats.miningbase_3_adjusted);
 }
 
 Entity.prototype.color_style = function() {
@@ -640,6 +640,22 @@ gg.factory('Match', ['$ggResource', '$compile', 'Matchnote', function($ggResourc
               }
 
               entity.summary.resource_collection_rate_adjusted = Math.round(entity.summary.resource_collection_rate*speed_multiplier)
+              if (entity.stats.mineral_saturation_1 != null) {
+	            entity.stats.mineral_saturation_1_adjusted = Math.round(entity.stats.mineral_saturation_1/speed_multiplier)
+              }
+              if (entity.stats.mineral_saturation_2 != null) {
+	            entity.stats.mineral_saturation_2_adjusted = Math.round(entity.stats.mineral_saturation_2/speed_multiplier)
+              }
+              if (entity.stats.mineral_saturation_3 != null) {
+	            entity.stats.mineral_saturation_3_adjusted = Math.round(entity.stats.mineral_saturation_3/speed_multiplier)
+              }
+
+              if (entity.stats.miningbase_2 != null) {
+	            entity.stats.miningbase_2_adjusted = Math.round(entity.stats.miningbase_2/speed_multiplier)
+              }
+              if (entity.stats.miningbase_3 != null) {
+	            entity.stats.miningbase_3_adjusted = Math.round(entity.stats.miningbase_3/speed_multiplier)
+              }
           }
           
           if(this.MineralsCurrent && this.MineralsCurrent[entity.identity.id]) {

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -164,12 +164,12 @@
                   <a href class="ggtipper2" title="When a second base is completed, and located directly next to the mineral patches." data-gravity="s">
                     2nd Mining Base Complete
                   </a>
-                </td><td ng-repeat="entity in match.entities">{{ entity.stats.miningbase_2 | minutes_seconds }}</td></tr>
+                </td><td ng-repeat="entity in match.entities">{{ entity.stats.miningbase_2_adjusted | minutes_seconds }}</td></tr>
               <tr><td>
                   <a href class="ggtipper2" title="When a third base is completed, and located directly next to the mineral patches." data-gravity="s">
                     3rd Mining Base Complete
                   </a>
-                </td><td ng-repeat="entity in match.entities">{{ entity.stats.miningbase_3 | minutes_seconds}}</td></tr>
+                </td><td ng-repeat="entity in match.entities">{{ entity.stats.miningbase_3_adjusted | minutes_seconds}}</td></tr>
               <tr><th>Saturation Speed</a></th>
                   <th ng-repeat="entity in match.doubleents" ng-show="$index % 2 == 0 || user.view_mode == 1">
                     <span ng-show="$index % 2 == 0">{{ entity.identity.name }}</span>
@@ -181,7 +181,7 @@
                     1 Base Mineral Income (870)</a>
                 </td>
                 <td ng-repeat="entity in match.doubleents" ng-show="$index % 2 == 0 || user.view_mode == 1">
-                  <span ng-show="$index % 2 == 0">{{ entity.stats.mineral_saturation_1 | minutes_seconds }}</span>
+                  <span ng-show="$index % 2 == 0">{{ entity.stats.mineral_saturation_1_adjusted | minutes_seconds }}</span>
                   <span ng-show="$index % 2 == 1" ><league data-league="{{ entity.sat_1_skill }}"></league></span>
                 </td></tr>
               <tr><td>


### PR DESCRIPTION
Aligns base completion and saturation times with other charts and in-game time. Only visual changes.

[Prod](http://ggtracker.com/matches/6832245):
<img width="994" alt="screen shot 2016-10-14 at 07 19 15" src="https://cloud.githubusercontent.com/assets/554455/19376495/9a87f6de-91de-11e6-982f-07d216616909.png">

Dev on this branch for same replay:
<img width="1010" alt="screen shot 2016-10-14 at 07 18 46" src="https://cloud.githubusercontent.com/assets/554455/19376502/a43b6f26-91de-11e6-82e0-e29890948e18.png">

It seems there's still a measurement problem for base completion time, see https://github.com/ggtracker/ggtrackerstack/issues/53 for more info. In this replay, it seems the completion times for `keys` is shifted by one, so time for 2nd base completed is actually when 3rd base completed and so on.
